### PR TITLE
Add sponsoring.kcvvelewijt.be → workers.dev (302 forced)

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -12,3 +12,4 @@
 /receptie                                                                                           https://forms.gle/3k3nQ7woex3124iv5                                                                               302
 /foodfriday                                                                                         https://forms.gle/38AeV5igBEjJj3r7A                                                                               302
 /recrea                                                                                             https://www.tournify.nl/live/kcvve-recrea25                                                                       302
+https://sponsoring.kcvvelewijt.be/*  https://kcvv-sponsorship-web.kevin-van-ransbeeck.workers.dev/:splat  302!


### PR DESCRIPTION
Adds a forced 302 redirect from `sponsoring.kcvvelewijt.be` → the workers.dev URL of the new sponsorship platform.

## Context

The KCVV sponsorship platform is deployed on Cloudflare Workers (private repo `soniCaH/kcvv-sponsoring`). Its canonical URL is `https://kcvv-sponsorship-web.kevin-van-ransbeeck.workers.dev`. We want `sponsoring.kcvvelewijt.be` as a memorable entry point.

The `kcvvelewijt.be` zone stays on Netlify (no zone migration to Cloudflare), so we can't point `sponsoring.*` directly at the Worker. Instead: `sponsoring.kcvvelewijt.be` is a domain alias on this Netlify site, with a forced 302 rule that bounces every request to the workers.dev URL.

## The rule

```
https://sponsoring.kcvvelewijt.be/*  https://kcvv-sponsorship-web.kevin-van-ransbeeck.workers.dev/:splat  302!
```

- **Full-URL `from`** scopes the rule to that one hostname; `www.kcvvelewijt.be` traffic is untouched.
- **`302!` (forced)** overrides Netlify's automatic "alias → primary domain" redirect, which would otherwise send `sponsoring.*` to `www.kcvvelewijt.be` instead of the app.
- **`302`, not `301`**, keeps the redirect reversible — if we ever move DNS to Cloudflare and point `sponsoring.*` directly at the Worker, browsers won't have a 301 cached.
- **`:splat`** preserves the path so deep links like `sponsoring.kcvvelewijt.be/deals/123` land correctly.

## Verify after deploy

```
curl -sI https://sponsoring.kcvvelewijt.be/ | head -3
# → HTTP/2 302
# location: https://kcvv-sponsorship-web.kevin-van-ransbeeck.workers.dev/
```

The domain alias on the Netlify site is already configured. Once this PR merges and Netlify rebuilds, the redirect goes live.
